### PR TITLE
Fixed array indexing issue that causes errors

### DIFF
--- a/asemica
+++ b/asemica
@@ -287,7 +287,7 @@ sub generate_transitions {
 	
 	### Generate the initial transitions table
 	foreach my $index (0..scalar(@tokens)){
-		my $token = $tokens[$index];
+		my $token = $tokens[$index-1];
 		my $key = lc($token);
 		
 		$transitions->{$key}->{seen}++;


### PR DESCRIPTION
This fixes issue #1.  

The change corrects an array index issue.  On the final iteration of the loop, $index is the length of the array, so it attempts to access an array index that doesn't exist.